### PR TITLE
Composite glyph

### DIFF
--- a/font/sbolv/biopolymer-amino-acid.js
+++ b/font/sbolv/biopolymer-amino-acid.js
@@ -8,9 +8,9 @@ function createGeometry(boxSize) {
 
 	var leftScale = 0.3;
 	var rightScale = 1.0 - leftScale;
-	var stemBottom = boxSize.y * 1.5;
-	var stemTop = boxSize.y * 0.40;
-	var stemStep = (stemBottom - stemTop) / 4.0;
+	var stemBottom = boxSize.y;
+	var stemTop = boxSize.y * -0.1;
+	var stemStep = (stemBottom - stemTop) / 4;
 	var xScaleLeftControl = .4;
 	var xScaleRightControl = 1.0 - xScaleLeftControl;
 	var yScaleLeft = .8;
@@ -31,11 +31,11 @@ function createGeometry(boxSize) {
 		stemThirdLeftControl: Vec2(boxSize.x * xScaleLeftControl, stemTop + (stemStep * 2) + (stemStep * yScaleLeft)),
 		stemBottom: Vec2(boxSize.x / 2.0, stemBottom),
 		stemBottomControl: Vec2(boxSize.x * xScaleRightControl, stemBottom),
-		
+
 		circleSizeX: boxSize.x * sizeScale,
 		circleSizeY: boxSize.y * sizeScale,
 		circleOffsetX: (boxSize.x / 2.0) - ((boxSize.x / 2.0) * sizeScale),
-		circleOffsetY: (-boxSize.y * sizeScale) * 0.5
+		circleOffsetY: (-boxSize.y * sizeScale) * 2
     };
 }
 
@@ -44,7 +44,7 @@ function renderGlyph(design, glyphObject, boxSize) {
     var geom = createGeometry(boxSize);
 
     var path = [
-		
+
 		'M' + Vec2.toPathString(geom.stemTop),
 		'C' + Vec2.toPathString(geom.stemTopControl) + ' ' + Vec2.toPathString(geom.stemFirstRightControl) + ' ' + Vec2.toPathString(geom.stemFirstRight),
 		'S' + Vec2.toPathString(geom.stemFirstLeftControl) + ' ' + Vec2.toPathString(geom.stemFirstLeft),
@@ -60,7 +60,7 @@ function renderGlyph(design, glyphObject, boxSize) {
 
     glyph.attr('stroke', glyphObject.color || '#000');
     glyph.attr('stroke-width', glyphObject.thickness || '4px');
-	glyph.attr('stroke-linecap', 'round');
+		glyph.attr('stroke-linecap', 'round');
     glyph.attr('stroke-linejoin', 'round');
     glyph.attr('fill', 'none');
 
@@ -83,7 +83,7 @@ function renderGlyph(design, glyphObject, boxSize) {
 
     return {
         glyph: group,
-        backboneOffset: boxSize.y * 1.5
+        backboneOffset: boxSize.y
     };
 }
 
@@ -96,5 +96,3 @@ module.exports = {
     }
 
 };
-
-

--- a/font/sbolv/biopolymer-base.js
+++ b/font/sbolv/biopolymer-base.js
@@ -6,12 +6,13 @@ function createGeometry(boxSize) {
 	var sizeScale = 0.4;
 	var offsetX = (boxSize.x / 2.0) - ((boxSize.x / 2.0) * sizeScale);
     return {
-        stemBottom: Vec2(boxSize.x / 2.0, boxSize.y * 1.5),
-        stemTop: Vec2(boxSize.x / 2.0, boxSize.y * 0.5),
+        stemBottom: Vec2(boxSize.x / 2.0, boxSize.y),
+        stemTop: Vec2(boxSize.x / 2.0, boxSize.y * -0.4),
+
 		circleSizeX: boxSize.x * sizeScale,
 		circleSizeY: boxSize.y * sizeScale,
 		circleOffsetX: (boxSize.x / 2.0) - ((boxSize.x / 2.0) * sizeScale),
-		circleOffsetY: (-boxSize.y * sizeScale) * 0.5
+		circleOffsetY: (-boxSize.y * sizeScale) * 1.5
     };
 }
 
@@ -23,10 +24,6 @@ function renderGlyph(design, glyphObject, boxSize) {
 
         'M' + Vec2.toPathString(geom.stemBottom),
         'L' + Vec2.toPathString(geom.stemTop),
-        // 'M' + Vec2.toPathString(geom.topLeft),
-        // 'L' + Vec2.toPathString(geom.bottomRight),
-		// 'M' + Vec2.toPathString(geom.topRight),
-        // 'L' + Vec2.toPathString(geom.bottomLeft),
 
     ].join('');
 
@@ -34,7 +31,7 @@ function renderGlyph(design, glyphObject, boxSize) {
 
     glyph.attr('stroke', glyphObject.color || '#000');
     glyph.attr('stroke-width', glyphObject.thickness || '4px');
-	glyph.attr('stroke-linecap', 'round');
+		glyph.attr('stroke-linecap', 'round');
     glyph.attr('stroke-linejoin', 'round');
     glyph.attr('fill', 'none');
 
@@ -57,7 +54,7 @@ function renderGlyph(design, glyphObject, boxSize) {
 
     return {
         glyph: group,
-        backboneOffset: boxSize.y * 1.5
+        backboneOffset: boxSize.y
     };
 }
 
@@ -70,5 +67,3 @@ module.exports = {
     }
 
 };
-
-

--- a/font/sbolv/biopolymer-junction.js
+++ b/font/sbolv/biopolymer-junction.js
@@ -9,8 +9,8 @@ function createGeometry(boxSize) {
 	var leftScale = 0.3;
 	var rightScale = 1.0 - leftScale;
 	var waveScale = .875;
-	var stemBottom = boxSize.y * 1.5;
-	var stemTop = boxSize.y * 0.4;
+	var stemBottom = boxSize.y;
+	var stemTop = boxSize.y * -0.1;
 	var stemStep = (stemBottom - stemTop) / 6;
     return {
 		stemTop: Vec2(boxSize.x / 2.0, stemTop),
@@ -24,7 +24,7 @@ function createGeometry(boxSize) {
 		circleSizeX: boxSize.x * sizeScale,
 		circleSizeY: boxSize.y * sizeScale,
 		circleOffsetX: (boxSize.x / 2.0) - ((boxSize.x / 2.0) * sizeScale),
-		circleOffsetY: (-boxSize.y * sizeScale) * 0.5
+		circleOffsetY: (-boxSize.y * sizeScale) * 1.5
     };
 }
 
@@ -48,7 +48,7 @@ function renderGlyph(design, glyphObject, boxSize) {
 
     glyph.attr('stroke', glyphObject.color || '#000');
     glyph.attr('stroke-width', glyphObject.thickness || '4px');
-	glyph.attr('stroke-linecap', 'round');
+		glyph.attr('stroke-linecap', 'round');
     glyph.attr('stroke-linejoin', 'round');
     glyph.attr('fill', 'none');
 
@@ -71,7 +71,7 @@ function renderGlyph(design, glyphObject, boxSize) {
 
     return {
         glyph: group,
-        backboneOffset: boxSize.y * 1.5
+        backboneOffset: boxSize.y
     };
 }
 
@@ -84,5 +84,3 @@ module.exports = {
     }
 
 };
-
-

--- a/font/sbolv/blunt-restriction-site.js
+++ b/font/sbolv/blunt-restriction-site.js
@@ -77,5 +77,3 @@ module.exports = {
 
 };
 
-
-

--- a/font/sbolv/composite.js
+++ b/font/sbolv/composite.js
@@ -1,0 +1,57 @@
+var Vec2 = require('../../lib/geom/vec2')
+var Rect = require('../../lib/geom/rect')
+
+
+function createGeometry(boxSize) {
+
+    return {
+         
+          topLeft:Vec2(0, boxSize.y),  
+          topRight: Vec2(boxSize.x , boxSize.y),  
+          bottomLeft: Vec2(-(boxSize.x * 0.3), boxSize.y * 1.3),  
+          bottomRight: Vec2(boxSize.x * 1.3, boxSize.y * 1.3)  
+   };
+}
+
+function renderGlyph(design, glyphObject, boxSize) {
+
+    var geom = createGeometry(boxSize);
+    var path = [
+
+        'M' + Vec2.toPathString(geom.topLeft),     
+        'L' + Vec2.toPathString(geom.bottomLeft),
+
+        'L' + Vec2.toPathString(geom.bottomRight),      
+        'L' + Vec2.toPathString(geom.topRight),
+
+    ].join('');
+     
+
+    var glyph = design.surface.path(path);
+    var group = design.surface.group();
+   
+    glyph.attr('stroke', 'black');
+    glyph.attr('fill','none');
+    glyph.attr('stroke-width', glyphObject.thickness ||'2px');
+    glyph.attr('stroke-linejoin', 'round');
+
+    group.add(glyph);
+
+
+    if(glyphObject.uri) {
+        group.attr('data-uri', glyphObject.uri);
+    }
+
+
+
+    return {
+        glyph: group
+        
+    };
+}
+
+module.exports = {
+
+    render: renderGlyph
+
+};

--- a/font/sbolv/composite.js
+++ b/font/sbolv/composite.js
@@ -5,38 +5,87 @@ var Rect = require('../../lib/geom/rect')
 function createGeometry(boxSize) {
 
     return {
-         
-          topLeft:Vec2(0, boxSize.y),  
-          topRight: Vec2(boxSize.x , boxSize.y),  
-          bottomLeft: Vec2(-(boxSize.x * 0.3), boxSize.y * 1.3),  
-          bottomRight: Vec2(boxSize.x * 1.3, boxSize.y * 1.3)  
-   };
+
+
+        // Slanted line on the left
+            topLeft:Vec2(0, boxSize.y),
+            topRight: Vec2(boxSize.x * -0.25 , boxSize.y * 1.25),
+        // First Bottom line Solid
+            Left:  Vec2(boxSize.x* -0.25,boxSize.y * 1.25),
+            Right: Vec2(boxSize.x * 0.26, boxSize.y * 1.25),
+        // Dashed Line in the Middle
+            MiddleLeft:  Vec2(boxSize.x * 0.3, boxSize.y * 1.25),
+            MiddleRight: Vec2(boxSize.x * 0.9, boxSize.y * 1.25),
+        // Second Bottom Line (Solid)
+            Left2:  Vec2(boxSize.x * 0.75, boxSize.y * 1.25),
+            Right2: Vec2(boxSize.x * 1.25, boxSize.y * 1.25),
+        // Slanted line on the right
+            bottomLeft: Vec2(boxSize.x, boxSize.y),
+            bottomRight: Vec2(boxSize.x * 1.25, boxSize.y * 1.25)
+
+    };
 }
 
 function renderGlyph(design, glyphObject, boxSize) {
 
     var geom = createGeometry(boxSize);
-    var path = [
+    var path1 = [
 
-        'M' + Vec2.toPathString(geom.topLeft),     
-        'L' + Vec2.toPathString(geom.bottomLeft),
-
-        'L' + Vec2.toPathString(geom.bottomRight),      
+        'M' + Vec2.toPathString(geom.topLeft),    // Dashed Left Line
         'L' + Vec2.toPathString(geom.topRight),
 
+        'M' + Vec2.toPathString(geom.bottomLeft),     // Dashed Right Line
+        'L' + Vec2.toPathString(geom.bottomRight),
+
     ].join('');
-     
 
-    var glyph = design.surface.path(path);
+    var path2 = [
+
+        'M' + Vec2.toPathString(geom.Left),
+        'L' + Vec2.toPathString(geom.Right),
+                                                    // 2 Disjoined Solid Lines
+        'M' + Vec2.toPathString(geom.Left2),
+        'L' + Vec2.toPathString(geom.Right2),
+
+
+    ].join('');
+
+    var path3 = [
+
+        'M' + Vec2.toPathString(geom.MiddleLeft),   // Dashed Line @ Bottom
+        'L' + Vec2.toPathString(geom.MiddleRight),
+
+    ].join('');
+
+
+    var glyph1 = design.surface.path(path1);
+    var glyph2 = design.surface.path(path2);
+    var glyph3 = design.surface.path(path3);
     var group = design.surface.group();
-   
-    glyph.attr('stroke', 'black');
-    glyph.attr('fill','none');
-    glyph.attr('stroke-width', glyphObject.thickness ||'2px');
-    glyph.attr('stroke-linejoin', 'round');
 
-    group.add(glyph);
+    // Specs for First Glyph
+    glyph1.attr('stroke', 'black');
+    glyph1.attr('fill', glyphObject.color || '#000000');
+    glyph1.attr('stroke-dasharray', "6,2")
+    glyph1.attr('stroke-width', glyphObject.thickness ||'2px');
+    glyph1.attr('stroke-linejoin', 'round');
 
+    // Second Glyph (Solid Lines Only)
+    glyph2.attr('stroke', 'black');
+    glyph2.attr('fill', glyphObject.color || '#000000');
+    glyph2.attr('stroke-width', glyphObject.thickness ||'2px');
+    glyph2.attr('stroke-linejoin', 'round');
+
+    //Third Glyph
+    glyph3.attr('stroke', 'black');
+    glyph3.attr('fill', glyphObject.color || '#000000');
+    glyph3.attr('stroke-dasharray', "3,5");
+    glyph3.attr('stroke-width', glyphObject.thickness ||'2px');
+    glyph3.attr('stroke-linejoin', 'round');
+
+    group.add(glyph1);
+    group.add(glyph2);
+    group.add(glyph3);
 
     if(glyphObject.uri) {
         group.attr('data-uri', glyphObject.uri);
@@ -45,8 +94,8 @@ function renderGlyph(design, glyphObject, boxSize) {
 
 
     return {
-        glyph: group
-        
+        glyph: group,
+        backboneOffset: boxSize.y
     };
 }
 

--- a/font/sbolv/protease-site.js
+++ b/font/sbolv/protease-site.js
@@ -5,8 +5,8 @@ function createGeometry(boxSize) {
 
 	var leftScale = 0.3;
 	var rightScale = 1.0 - leftScale;
-	var stemBottom = boxSize.y * 1.5;
-	var stemTop = boxSize.y * 0.40;
+	var stemBottom = boxSize.y;
+	var stemTop = boxSize.y * -0.1;
 	var stemStep = (stemBottom - stemTop) / 4.0;
 	var xScaleLeftControl = .4;
 	var xScaleRightControl = 1.0 - xScaleLeftControl;
@@ -28,10 +28,11 @@ function createGeometry(boxSize) {
 		stemThirdLeftControl: Vec2(boxSize.x * xScaleLeftControl, stemTop + (stemStep * 2) + (stemStep * yScaleLeft)),
 		stemBottom: Vec2(boxSize.x / 2.0, stemBottom),
 		stemBottomControl: Vec2(boxSize.x * xScaleRightControl, stemBottom),
-        topLeft: Vec2(boxSize.x * leftScale, 0),
-        topRight: Vec2(boxSize.x * rightScale, 0),
-		bottomLeft: Vec2(boxSize.x * leftScale, boxSize.y * 0.7),
-		bottomRight: Vec2(boxSize.x * rightScale, boxSize.y * 0.7)
+
+		topLeft: Vec2(boxSize.x * leftScale, boxSize.y * -0.5),
+		topRight: Vec2(boxSize.x * rightScale, boxSize.y * -0.5),
+		bottomLeft: Vec2(boxSize.x * leftScale, boxSize.y * 0.1),
+		bottomRight: Vec2(boxSize.x * rightScale, boxSize.y * 0.1)
     };
 }
 
@@ -49,11 +50,11 @@ function renderGlyph(design, glyphObject, boxSize) {
 		'S' + Vec2.toPathString(geom.stemThirdRightControl) + ' ' + Vec2.toPathString(geom.stemThirdRight),
 		'S' + Vec2.toPathString(geom.stemThirdLeftControl) + ' ' + Vec2.toPathString(geom.stemThirdLeft),
 		'S' + Vec2.toPathString(geom.stemBottomControl) + ' ' + Vec2.toPathString(geom.stemBottom),
-		
-        'M' + Vec2.toPathString(geom.topLeft),
-        'L' + Vec2.toPathString(geom.bottomRight),
+
+		'M' + Vec2.toPathString(geom.topLeft),
+		'L' + Vec2.toPathString(geom.bottomRight),
 		'M' + Vec2.toPathString(geom.topRight),
-        'L' + Vec2.toPathString(geom.bottomLeft),
+		'L' + Vec2.toPathString(geom.bottomLeft),
 		'M' + Vec2.toPathString(geom.stemTop),
     ].join('');
 
@@ -61,7 +62,7 @@ function renderGlyph(design, glyphObject, boxSize) {
 
     glyph.attr('stroke', glyphObject.color || '#000');
     glyph.attr('stroke-width', glyphObject.thickness || '4px');
-	glyph.attr('stroke-linecap', 'round');
+		glyph.attr('stroke-linecap', 'round');
     glyph.attr('stroke-linejoin', 'round');
     glyph.attr('fill', 'none');
 
@@ -69,15 +70,15 @@ function renderGlyph(design, glyphObject, boxSize) {
     boundingBox.attr('fill-opacity', 0);
 
 	var group = design.surface.group();
-	group.add(glyph);
-	group.add(boundingBox);
+		group.add(glyph);
+		group.add(boundingBox);
 
     if(glyphObject.uri)
         group.attr('data-uri', glyphObject.uri)
 
     return {
         glyph: group,
-        backboneOffset: boxSize.y * 1.5
+        backboneOffset: boxSize.y
     };
 }
 
@@ -90,5 +91,3 @@ module.exports = {
     }
 
 };
-
-

--- a/font/sbolv/protein-stability.js
+++ b/font/sbolv/protein-stability.js
@@ -2,22 +2,17 @@
 var Vec2 = require('../../lib/geom/vec2')
 
 function createGeometry(boxSize) {
-	
+
 	var leftScale = 0.3;
 	var rightScale = 1.0 - leftScale;
-	var stemBottom = boxSize.y * 1.5;
-	var stemTop = boxSize.y * 0.40;
+	var stemBottom = boxSize.y;
+	var stemTop = boxSize.y * -0.1;
 	var stemStep = (stemBottom - stemTop) / 4.0;
 	var xScaleLeftControl = .4;
 	var xScaleRightControl = 1.0 - xScaleLeftControl;
 	var yScaleLeft = .8;
 
-	var polygonScaleX = 0.225;
-	var polygonScaleLeft = 1.0 - polygonScaleX;
-	var polygonScaleRight = 1.0 + polygonScaleX;
-	var polygonTop = 0.0;
-	var polygonMid = stemTop * 0.65;
-		
+
     return {
 		stemTop: Vec2(boxSize.x / 2.0, stemTop),
 		stemTopControl: Vec2(boxSize.x * xScaleRightControl, stemTop),
@@ -36,10 +31,11 @@ function createGeometry(boxSize) {
 		stemBottom: Vec2(boxSize.x / 2.0, stemBottom),
 		stemBottomControl: Vec2(boxSize.x * xScaleRightControl, stemBottom),
 
-		polygonTopLeft: Vec2((boxSize.x / 2.0) * polygonScaleLeft, polygonTop),
-		polygonTopRight: Vec2((boxSize.x / 2.0) * polygonScaleRight, polygonTop),
-		polygonBottomLeft: Vec2((boxSize.x / 2.0) * polygonScaleLeft, polygonMid),
-		polygonBottomRight: Vec2((boxSize.x / 2.0) * polygonScaleRight, polygonMid),
+		polygonBottomLeft: Vec2((boxSize.x) / 1.6 ,boxSize.y * -0.3),
+		polygonBottomRight: Vec2((boxSize.x) /2.4, boxSize.y * -0.3 ),
+		polygonTopLeft: Vec2((boxSize.x) / 1.6,boxSize.y * -0.5) ,
+		polygonTopRight: Vec2((boxSize.x) / 2.4 ,boxSize.y * -0.5 ),
+		polygonMid: Vec2(boxSize.x/ 2 , stemTop )
     };
 }
 
@@ -48,7 +44,7 @@ function renderGlyph(design, glyphObject, boxSize) {
     var geom = createGeometry(boxSize);
 
     var path = [
-		
+
 		'M' + Vec2.toPathString(geom.stemTop),
 		'C' + Vec2.toPathString(geom.stemTopControl) + ' ' + Vec2.toPathString(geom.stemFirstRightControl) + ' ' + Vec2.toPathString(geom.stemFirstRight),
 		'S' + Vec2.toPathString(geom.stemFirstLeftControl) + ' ' + Vec2.toPathString(geom.stemFirstLeft),
@@ -72,12 +68,12 @@ function renderGlyph(design, glyphObject, boxSize) {
     boundingBox.attr('fill-opacity', 0);
 
 	var polygonPath = [
-		'M' + Vec2.toPathString(geom.stemTop),
+		'M' + Vec2.toPathString(geom.polygonMid),
 		'L' + Vec2.toPathString(geom.polygonBottomLeft),
 		'L' + Vec2.toPathString(geom.polygonTopLeft),
 		'L' + Vec2.toPathString(geom.polygonTopRight),
 		'L' + Vec2.toPathString(geom.polygonBottomRight),
-		'Z'
+		'L'	+ Vec2.toPathString(geom.polygonMid),
 	].join('');
 
 	var polygon = design.surface.path(polygonPath)
@@ -95,7 +91,7 @@ function renderGlyph(design, glyphObject, boxSize) {
 
     return {
         glyph: group,
-        backboneOffset: boxSize.y * 1.5
+        backboneOffset: boxSize.y
     };
 }
 
@@ -108,5 +104,3 @@ module.exports = {
     }
 
 };
-
-

--- a/font/sbolv/restriction-site.js
+++ b/font/sbolv/restriction-site.js
@@ -6,12 +6,12 @@ function createGeometry(boxSize) {
 	var leftScale = 0.3
 	var rightScale = 1.0 - leftScale
     return {
-        stemBottom: Vec2(boxSize.x / 2.0, boxSize.y * 1.5),
-        stemTop: Vec2(boxSize.x / 2.0, boxSize.y * 0.4),
-        topLeft: Vec2(boxSize.x * leftScale, 0),
-        topRight: Vec2(boxSize.x * rightScale, 0),
-		bottomLeft: Vec2(boxSize.x * leftScale, boxSize.y * 0.7),
-		bottomRight: Vec2(boxSize.x * rightScale, boxSize.y * 0.7)
+        stemBottom: Vec2(boxSize.x / 2.0, boxSize.y),
+        stemTop: Vec2(boxSize.x / 2.0, 0),
+        topLeft: Vec2(boxSize.x * leftScale, -0.5 * boxSize.y),
+        topRight: Vec2(boxSize.x * rightScale, -0.5 * boxSize.y),
+		bottomLeft: Vec2(boxSize.x * leftScale, boxSize.y * 0.1),
+		bottomRight: Vec2(boxSize.x * rightScale, boxSize.y * 0.1)
     };
 }
 
@@ -38,7 +38,7 @@ function renderGlyph(design, glyphObject, boxSize) {
     glyph.attr('stroke-linejoin', 'round');
     glyph.attr('fill', 'none');
 
-	boundingBox = design.surface.rect(boxSize.x, boxSize.y * 1.5);
+	boundingBox = design.surface.rect(boxSize.x, boxSize.y * 2);
     boundingBox.attr('fill-opacity', 0);
 
 	var group = design.surface.group();
@@ -50,7 +50,7 @@ function renderGlyph(design, glyphObject, boxSize) {
 
     return {
         glyph: group,
-        backboneOffset: boxSize.y * 1.5
+        backboneOffset: boxSize.y
     };
 }
 

--- a/font/sbolv/restriction-site.js
+++ b/font/sbolv/restriction-site.js
@@ -10,8 +10,9 @@ function createGeometry(boxSize) {
         stemTop: Vec2(boxSize.x / 2.0, 0),
         topLeft: Vec2(boxSize.x * leftScale, -0.5 * boxSize.y),
         topRight: Vec2(boxSize.x * rightScale, -0.5 * boxSize.y),
-		bottomLeft: Vec2(boxSize.x * leftScale, boxSize.y * 0.1),
-		bottomRight: Vec2(boxSize.x * rightScale, boxSize.y * 0.1)
+
+				bottomLeft: Vec2(boxSize.x * leftScale, boxSize.y * 0.1),
+				bottomRight: Vec2(boxSize.x * rightScale, boxSize.y * 0.1)
     };
 }
 
@@ -25,7 +26,7 @@ function renderGlyph(design, glyphObject, boxSize) {
         'L' + Vec2.toPathString(geom.stemTop),
         'M' + Vec2.toPathString(geom.topLeft),
         'L' + Vec2.toPathString(geom.bottomRight),
-		'M' + Vec2.toPathString(geom.topRight),
+				'M' + Vec2.toPathString(geom.topRight),
         'L' + Vec2.toPathString(geom.bottomLeft),
 
     ].join('');
@@ -34,7 +35,7 @@ function renderGlyph(design, glyphObject, boxSize) {
 
     glyph.attr('stroke', glyphObject.color || '#000');
     glyph.attr('stroke-width', glyphObject.thickness || '4px');
-	glyph.attr('stroke-linecap', 'round');
+		glyph.attr('stroke-linecap', 'round');
     glyph.attr('stroke-linejoin', 'round');
     glyph.attr('fill', 'none');
 
@@ -42,8 +43,8 @@ function renderGlyph(design, glyphObject, boxSize) {
     boundingBox.attr('fill-opacity', 0);
 
 	var group = design.surface.group();
-	group.add(glyph);
-	group.add(boundingBox);
+		group.add(glyph);
+		group.add(boundingBox);
 
     if(glyphObject.uri)
         group.attr('data-uri', glyphObject.uri)
@@ -63,6 +64,3 @@ module.exports = {
     }
 
 };
-
-
-

--- a/font/sbolv/ribonuclease-site.js
+++ b/font/sbolv/ribonuclease-site.js
@@ -6,8 +6,8 @@ function createGeometry(boxSize) {
 	var leftScale = 0.3;
 	var rightScale = 1.0 - leftScale;
 	var waveScale = .875;
-	var stemBottom = boxSize.y * 1.5;
-	var stemTop = boxSize.y * 0.4;
+	var stemBottom = boxSize.y;
+	var stemTop = boxSize.y * -0.1;
 	var stemStep = (stemBottom - stemTop) / 6;
     return {
 		stemTop: Vec2(boxSize.x / 2.0, stemTop),
@@ -18,10 +18,11 @@ function createGeometry(boxSize) {
 		stemFourth: Vec2(boxSize.x / 2.0, stemTop + (stemStep * 4)),
 		stemFifth: Vec2(boxSize.x / 2.0, stemTop + (stemStep * 5)),
 		stemBottom: Vec2(boxSize.x / 2.0, stemBottom),
-        topLeft: Vec2(boxSize.x * leftScale, 0),
-        topRight: Vec2(boxSize.x * rightScale, 0),
-		bottomLeft: Vec2(boxSize.x * leftScale, boxSize.y * 0.7),
-		bottomRight: Vec2(boxSize.x * rightScale, boxSize.y * 0.7)
+
+		topLeft: Vec2(boxSize.x * leftScale, boxSize.y * -0.5),
+		topRight: Vec2(boxSize.x * rightScale, boxSize.y * -0.5),
+		bottomLeft: Vec2(boxSize.x * leftScale, boxSize.y * 0.1),
+		bottomRight: Vec2(boxSize.x * rightScale, boxSize.y * 0.1)
     };
 }
 
@@ -38,11 +39,11 @@ function renderGlyph(design, glyphObject, boxSize) {
 		'T' + Vec2.toPathString(geom.stemFourth),
 		'T' + Vec2.toPathString(geom.stemFifth),
 		'T' + Vec2.toPathString(geom.stemBottom),
-		
-        'M' + Vec2.toPathString(geom.topLeft),
-        'L' + Vec2.toPathString(geom.bottomRight),
+
+    'M' + Vec2.toPathString(geom.topLeft),
+    'L' + Vec2.toPathString(geom.bottomRight),
 		'M' + Vec2.toPathString(geom.topRight),
-        'L' + Vec2.toPathString(geom.bottomLeft),
+    'L' + Vec2.toPathString(geom.bottomLeft),
 		'M' + Vec2.toPathString(geom.stemTop),
     ].join('');
 
@@ -50,7 +51,7 @@ function renderGlyph(design, glyphObject, boxSize) {
 
     glyph.attr('stroke', glyphObject.color || '#000');
     glyph.attr('stroke-width', glyphObject.thickness || '4px');
-	glyph.attr('stroke-linecap', 'round');
+		glyph.attr('stroke-linecap', 'round');
     glyph.attr('stroke-linejoin', 'round');
     glyph.attr('fill', 'none');
 
@@ -58,15 +59,15 @@ function renderGlyph(design, glyphObject, boxSize) {
     boundingBox.attr('fill-opacity', 0);
 
 	var group = design.surface.group();
-	group.add(glyph);
-	group.add(boundingBox);
+		group.add(glyph);
+		group.add(boundingBox);
 
     if(glyphObject.uri)
         group.attr('data-uri', glyphObject.uri)
 
     return {
         glyph: group,
-        backboneOffset: boxSize.y * 1.5
+        backboneOffset: boxSize.y
     };
 }
 
@@ -79,5 +80,3 @@ module.exports = {
     }
 
 };
-
-

--- a/font/sbolv/rna-stability.js
+++ b/font/sbolv/rna-stability.js
@@ -3,17 +3,11 @@ var Vec2 = require('../../lib/geom/vec2')
 
 function createGeometry(boxSize) {
 
-	var waveScale = .875;
-	var stemBottom = boxSize.y * 1.5;
-	var stemTop = boxSize.y * 0.4;
-	var stemStep = (stemBottom - stemTop) / 6;
+	var waveScale =  .875;
+	var stemBottom = boxSize.y;
+	var stemTop = boxSize.y * -0.1;
+	var stemStep = (stemBottom - stemTop) / 6
 
-	var polygonScaleX = 0.225;
-	var polygonScaleLeft = 1.0 - polygonScaleX;
-	var polygonScaleRight = 1.0 + polygonScaleX;
-	var polygonTop = 0.0;
-	var polygonMid = stemTop * 0.65;
-		
     return {
 		stemTop: Vec2(boxSize.x / 2.0, stemTop),
 		stemControl: Vec2((boxSize.x / 2.0) * waveScale, stemTop + (stemStep / 2.0)),
@@ -23,11 +17,12 @@ function createGeometry(boxSize) {
 		stemFourth: Vec2(boxSize.x / 2.0, stemTop + (stemStep * 4)),
 		stemFifth: Vec2(boxSize.x / 2.0, stemTop + (stemStep * 5)),
 		stemBottom: Vec2(boxSize.x / 2.0, stemBottom),
-		
-		polygonTopLeft: Vec2((boxSize.x / 2.0) * polygonScaleLeft, polygonTop),
-		polygonTopRight: Vec2((boxSize.x / 2.0) * polygonScaleRight, polygonTop),
-		polygonBottomLeft: Vec2((boxSize.x / 2.0) * polygonScaleLeft, polygonMid),
-		polygonBottomRight: Vec2((boxSize.x / 2.0) * polygonScaleRight, polygonMid),
+
+		polygonBottomLeft: Vec2((boxSize.x) / 1.6 ,boxSize.y * -0.3),
+		polygonBottomRight: Vec2((boxSize.x) /2.4, boxSize.y * -0.3 ),
+		polygonTopLeft: Vec2((boxSize.x) / 1.6,boxSize.y * -0.5) ,
+		polygonTopRight: Vec2((boxSize.x) / 2.4 ,boxSize.y * -0.5 ),
+		polygonMid: Vec2(boxSize.x/ 2 , stemTop )
     };
 }
 
@@ -51,7 +46,7 @@ function renderGlyph(design, glyphObject, boxSize) {
 
     glyph.attr('stroke', glyphObject.color || '#000');
     glyph.attr('stroke-width', glyphObject.thickness || '4px');
-	glyph.attr('stroke-linecap', 'round');
+		glyph.attr('stroke-linecap', 'round');
     glyph.attr('stroke-linejoin', 'round');
     glyph.attr('fill', 'none');
 
@@ -59,12 +54,13 @@ function renderGlyph(design, glyphObject, boxSize) {
     boundingBox.attr('fill-opacity', 0);
 
 	var polygonPath = [
-		'M' + Vec2.toPathString(geom.stemTop),
+		'M' + Vec2.toPathString(geom.polygonMid),
 		'L' + Vec2.toPathString(geom.polygonBottomLeft),
 		'L' + Vec2.toPathString(geom.polygonTopLeft),
 		'L' + Vec2.toPathString(geom.polygonTopRight),
 		'L' + Vec2.toPathString(geom.polygonBottomRight),
-		'Z'
+		'L'	+ Vec2.toPathString(geom.polygonMid),
+
 	].join('');
 
 	var polygon = design.surface.path(polygonPath)
@@ -82,7 +78,7 @@ function renderGlyph(design, glyphObject, boxSize) {
 
     return {
         glyph: group,
-        backboneOffset: boxSize.y * 1.5
+        backboneOffset: boxSize.y
     };
 }
 
@@ -95,5 +91,3 @@ module.exports = {
     }
 
 };
-
-

--- a/font/sbolv/signature.js
+++ b/font/sbolv/signature.js
@@ -80,11 +80,6 @@ function renderGlyph(design, glyphObject, boxSize) {
 module.exports = {
 
     render: renderGlyph,
-
-    insets: {
-        top: 0.2
-    }
-
 };
 
 

--- a/font/sbolv/unspecified.js
+++ b/font/sbolv/unspecified.js
@@ -12,7 +12,7 @@ function createGeometry(boxSize) {
             bottom: Vec2(x / 2, y),
         };
     }
-    
+
 
 function renderGlyph(design, glyphObject, boxSize) {
 
@@ -31,18 +31,20 @@ function renderGlyph(design, glyphObject, boxSize) {
 	group.add(fill);
 
     var path = [
-        'M' + Vec2.toPathString(geom.top),  
+        'M' + Vec2.toPathString(geom.top),
         'L' + Vec2.toPathString(geom.left),
         'L' + Vec2.toPathString(geom.bottom),
         'L' + Vec2.toPathString(geom.right),
         'Z'
     ].join("")
 
-    let question = design.surface.text('?').move(boxSize.x / 2, geom.bottom.y / 6);
-    
+    let question = design.surface.text('?').move(boxSize.x / 2, geom.bottom.y / 7);
+    let dot = design.surface.text('.').move(boxSize.x/2.14, geom.bottom.y / 3.5) 
+
     question.attr('text-anchor', 'middle');
 
     group.add(question)
+    group.add(dot)
     group.add(design.surface.path(path))
 
     var glyph = group;
@@ -59,7 +61,7 @@ function renderGlyph(design, glyphObject, boxSize) {
 
     return {
         glyph: group,
-        backboneOffset: 5 * boxSize.y / 4
+        backboneOffset: boxSize.y
     };
 }
 

--- a/lib/colorLibrary/color.js
+++ b/lib/colorLibrary/color.js
@@ -1,13 +1,49 @@
 
 const colors = [
-  /*{
-    colorName: 'SILVER',
-    colorCode: '#C0C0C0'
+   {
+    colorName: 'DarkGoldenrod',
+    colorCode: '#B8860B	'
    },
    {
-    colorName: 'GRAY',
-    colorCode: '#808080'
-   },*/
+    colorName: 'SeaGreen',
+    colorCode: '#2E8B57'
+   },
+   {
+    colorName: 'HotPink',
+    colorCode: '#FF69B4	'
+   },
+   {
+    colorName: 'MediumVioletRed',
+    colorCode: '#C71585'
+   },
+   {
+    colorName: 'MediumTurquoise',
+    colorCode: '#48D1CC'
+   },
+   {
+    colorName: 'SteelBlue',
+    colorCode: '#4682B4'
+   },
+   {
+    colorName: 'DimGray',
+    colorCode: '#696969'
+   },
+   {
+    colorName: 'Goldenrod',
+    colorCode: '#DAA520'
+   },
+   {
+    colorName: 'DeepSkyBlue',
+    colorCode: '#00BFFF'
+   },
+   {
+    colorName: 'SlateBlue',
+    colorCode: '#6A5ACD'
+   },
+   {
+    colorName: 'Brown',
+    colorCode: '#A52A2A	'
+   },
    {
     colorName: 'RED',
     colorCode: '#FF0000'
@@ -15,10 +51,6 @@ const colors = [
    {
     colorName: 'MAROON',
     colorCode: '#800000'
-   },
-   {
-    colorName: 'YELLOW',
-    colorCode: '#FFFF00'
    },
    {
     colorName: 'OLIVE',

--- a/lib/colorLibrary/color.js
+++ b/lib/colorLibrary/color.js
@@ -1,0 +1,140 @@
+
+const colors = [
+  /*{
+    colorName: 'SILVER',
+    colorCode: '#C0C0C0'
+   },
+   {
+    colorName: 'GRAY',
+    colorCode: '#808080'
+   },*/
+   {
+    colorName: 'RED',
+    colorCode: '#FF0000'
+   },
+   {
+    colorName: 'MAROON',
+    colorCode: '#800000'
+   },
+   {
+    colorName: 'YELLOW',
+    colorCode: '#FFFF00'
+   },
+   {
+    colorName: 'OLIVE',
+    colorCode: '#808000'
+   },
+   {
+    colorName: 'LIME',
+    colorCode: '#00FF00'
+   },
+   {
+    colorName: 'GREEN',
+    colorCode: '#008000'
+   },
+   {
+    colorName: 'AQUA',
+    colorCode: '#00FFFF'
+   },
+   {
+    colorName: 'TEAL', 
+    colorCode: '#008080'
+   },
+   {
+    colorName: 'BLUE', 
+    colorCode: '#0000FF'
+   },
+   {
+    colorName: 'NAVY', 
+    colorCode: '#000080'
+   },
+   {
+    colorName: 'FUCHSIA', 
+    colorCode: '#FF00FF'
+   },
+    {
+    colorName: 'PURPLE', 
+    colorCode: '#800080'
+   },
+   {
+    colorName: 'BRWON', 
+    colorCode: '#A52A2A	'
+   },
+   {
+    colorName: 'SandyBrown', 
+    colorCode: '#F4A460'
+   },
+   {
+    colorName: 'RosyBrown', 
+    colorCode: '#BC8F8F'
+   },{
+    colorName: 'Peru', 
+    colorCode: '#CD853F'
+   },
+   {
+    colorName: 'Chocolate', 
+    colorCode: '#D2691E'
+   },
+   {
+    colorName: 'DarkBlue', 
+    colorCode: '#00008B'
+   },
+   {
+    colorName: 'MidnightBlue', 
+    colorCode: '#191970'
+   },
+   {
+    colorName: 'FireBrick', 
+    colorCode: '#B22222'
+   },
+   {
+    colorName: 'Salmon', 
+    colorCode: '#FA8072'
+   },
+   {
+    colorName: 'ForestGreen', 
+    colorCode: '#228B22'
+   },
+   {
+    colorName: 'LawnGreen', 
+    colorCode: '#7CFC00'
+   },
+   {
+    colorName: 'Indigo', 
+    colorCode: '#4B0082	'
+   },
+   {
+    colorName: 'Fuchsia', 
+    colorCode: '#FF00FF'
+   },
+   {
+    colorName: 'Lavender', 
+    colorCode: '#E6E6FA'
+   },
+   {
+    colorName: 'Tomato', 
+    colorCode: '#FF6347'
+   },
+   {
+    colorName: 'Orange', 
+    colorCode: '#FFA500'
+   },
+   {
+    colorName: 'Khaki', 
+    colorCode: '#F0E68C'
+   },
+   {
+    colorName: 'Teal', 
+    colorCode: '#008080'
+   },
+   {
+    colorName: 'DarkSlateGray', 
+    colorCode: '#2F4F4F'
+   }
+]; 
+
+module.exports = {
+
+    colors: colors
+
+};

--- a/lib/component.js
+++ b/lib/component.js
@@ -8,10 +8,28 @@ var Segment = require('./segment'),
         
 function renderComponent(design, component) {
 
+    
+    //populating compositeGlyph array
+    let compositeGlyphs = [];
+    for (let i = 0; i < component.segments.length; ++i) { 
+      if ( component.segments[i].sequence.length > 1 ) {
+        compositeGlyphs.push(component.segments[i].name);
+      }
+    }
+
     var segmentPos = Matrix();
 
     var segments = component.segments.map(function(segment) {
-
+     
+         
+        //labeling composite glyphs in segment sequences 
+        for (let i in compositeGlyphs) {
+           for (let j in segment.sequence) {
+             if (segment.sequence[j].name === compositeGlyphs[i]) 
+               segment.sequence[j].isComposite = true;
+           } 
+        }
+         
         var segment = Segment.render(design, segment);
 
         var boundingBox = Rect(segment.bbox());

--- a/lib/component.js
+++ b/lib/component.js
@@ -6,7 +6,7 @@ var Segment = require('./segment'),
     Matrix = require('./geom/matrix'),
     Linker = require('./linker'),
     Colors = require('./colorLibrary/color')
-        
+
 function renderComponent(design, component) {
 
     //initializing color object for coloring sub part labels
@@ -16,8 +16,9 @@ function renderComponent(design, component) {
 
     //populating compositeGlyph array
     let compositeGlyphs = [];
-    for (let i = 0; i < component.segments.length; ++i) { 
-      if ( component.segments[i].sequence.length > 1 ) {
+    for (let i = 0; i < component.segments.length; ++i) {
+      if ( component.segments[i].sequence.length > 1 ||
+           (component.segments[i].sequence.length === 1 && component.segments[i].name !== component.segments[i].sequence[0].name)) {
         compositeGlyphs.push({name: component.segments[i].name, segmentIndex: i});
       }
     }
@@ -33,18 +34,16 @@ function renderComponent(design, component) {
               component.segments[i].sequence[k].labelColor = colors.colors[colors.colorIndex].colorName;
               //set the label color for subParts
               component.segments[compositeGlyphs[j].segmentIndex].labelColor = colors.colors[colors.colorIndex++].colorName;
-              
-              //colors.colorIndex++;
              }
            }
-         } 
-       } 
+         }
+       }
      }
 
     var segmentPos = Matrix();
 
     var segments = component.segments.map(function(segment) {
-              
+
         var segment = Segment.render(design, segment);
 
         var boundingBox = Rect(segment.bbox());
@@ -74,7 +73,7 @@ function renderComponent(design, component) {
         var entity = Entity.render(design, entityObject);
 
         entity.move(10, 10);
-        
+
         return entity;
     });
 
@@ -109,4 +108,3 @@ function renderComponent(design, component) {
 module.exports = {
     render: renderComponent
 }
-

--- a/lib/component.js
+++ b/lib/component.js
@@ -4,32 +4,47 @@ var Segment = require('./segment'),
     Rect = require('./geom/rect'),
     Vec2 = require('./geom/vec2')
     Matrix = require('./geom/matrix'),
-    Linker = require('./linker');
+    Linker = require('./linker'),
+    Colors = require('./colorLibrary/color')
         
 function renderComponent(design, component) {
 
-    
+    //initializing color object for coloring sub part labels
+    let colors = {};
+    colors.colors = Colors.colors;
+    colors.colorIndex = 0;
+
     //populating compositeGlyph array
     let compositeGlyphs = [];
     for (let i = 0; i < component.segments.length; ++i) { 
       if ( component.segments[i].sequence.length > 1 ) {
-        compositeGlyphs.push(component.segments[i].name);
+        compositeGlyphs.push({name: component.segments[i].name, segmentIndex: i});
       }
     }
+
+   //detecting composite glyphs and coloring composite parts  and their subpart labels
+    for (let i = 0; i < component.segments.length; ++i) {
+      for (let j in compositeGlyphs) {
+        for (let k in component.segments[i].sequence) {
+          if ( component.segments[i].sequence[k].name === compositeGlyphs[j].name)  {
+            component.segments[i].sequence[k].isComposite = true;
+            if ( colors.colorIndex < colors.colors.length ) {
+              //set the label color for composite glyph
+              component.segments[i].sequence[k].labelColor = colors.colors[colors.colorIndex].colorName;
+              //set the label color for subParts
+              component.segments[compositeGlyphs[j].segmentIndex].labelColor = colors.colors[colors.colorIndex++].colorName;
+              
+              //colors.colorIndex++;
+             }
+           }
+         } 
+       } 
+     }
 
     var segmentPos = Matrix();
 
     var segments = component.segments.map(function(segment) {
-     
-         
-        //labeling composite glyphs in segment sequences 
-        for (let i in compositeGlyphs) {
-           for (let j in segment.sequence) {
-             if (segment.sequence[j].name === compositeGlyphs[i]) 
-               segment.sequence[j].isComposite = true;
-           } 
-        }
-         
+              
         var segment = Segment.render(design, segment);
 
         var boundingBox = Rect(segment.bbox());

--- a/lib/displayList.js
+++ b/lib/displayList.js
@@ -257,3 +257,4 @@ module.exports = DisplayList;
 
 
 
+

--- a/lib/getDisplayList.js
+++ b/lib/getDisplayList.js
@@ -369,3 +369,4 @@ function sortedSubComponents(componentDefinition) {
 
 
 module.exports = getDisplayList
+

--- a/lib/segment.js
+++ b/lib/segment.js
@@ -1,10 +1,11 @@
 
 var Rect = require('./geom/rect'),
     Vec2 = require('./geom/vec2'),
-    Matrix = require('./geom/matrix');
+    Matrix = require('./geom/matrix'),
+    Composite = require('../font/sbolv/composite')
 
 function renderSegment(design, segment) {
-
+   
     var surface = design.surface;
 
     var glyphOffset = 0;
@@ -58,15 +59,36 @@ function renderSegment(design, segment) {
         var glyphProps = glyph.render(design, glyphObject, boundingBoxSize);
 
         var glyph = glyphProps.glyph;
+         
         var backboneOffset = glyphProps.backboneOffset;
 
         var glyphMatrix = Matrix();
         var labelMatrix = Matrix();
+         
+        //if glyph object is composite, build the composite object 
+        if (glyphObject.isComposite) { 
+           var compositeProps = Composite.render(design, glyphObject, boundingBoxSize );
+           var compositeGlyph = compositeProps.glyph;
+           var compositeBackboneOffset = compositeProps.backboneOffset;
+           var compositeMatrix = Matrix();
+           compositeMatrix = Matrix.translate(compositeMatrix, Vec2(0, -backboneOffset));
+           compositeMatrix = Matrix.translate(compositeMatrix, Vec2(glyphOffset, 0));
+
+           if(glyphObject.strand === 'negative') {
+            
+            compositeMatrix = Matrix.translate(compositeMatrix, Vec2(0, backboneOffset));
+            compositeMatrix = Matrix.rotate(compositeMatrix, 180, Vec2(boundingBoxSize.x, 0));
+            compositeMatrix = Matrix.translate(compositeMatrix, Vec2(boundingBoxSize.x, 0));
+            compositeMatrix = Matrix.translate(compositeMatrix, Vec2(0, -backboneOffset));
+           }
+           compositeGlyph.transform({ matrix: Matrix.toSVGString(compositeMatrix) });
+        }
 
         glyphMatrix = Matrix.translate(glyphMatrix, Vec2(0, -backboneOffset));
 
         glyphMatrix = Matrix.translate(glyphMatrix, Vec2(glyphOffset, 0));
 
+         
         if(glyphObject.strand === 'negative') {
 
             glyphMatrix = Matrix.translate(glyphMatrix, Vec2(0, backboneOffset));
@@ -77,11 +99,9 @@ function renderSegment(design, segment) {
 
         glyph.transform({ matrix: Matrix.toSVGString(glyphMatrix) });
 
-
         var glyphBBox = Rect(glyph.bbox());
 
         var labelText;
-
         if(glyphObject.name !== undefined) {
 
             labelText = design.surface.text('');
@@ -90,7 +110,15 @@ function renderSegment(design, segment) {
 
             labelText.build(true);
 
-            var label = labelText.tspan(glyphObject.name);
+            var label;
+            
+            //Add "composite" string to label if glyph object is composite
+            if (glyphObject.isComposite) {
+              label = labelText.tspan('Composite ' + glyphObject.name);
+            }
+            else {
+              label = labelText.tspan(glyphObject.name);
+            }
 
             label.attr('alignment-baseline', 'middle');
 
@@ -110,6 +138,9 @@ function renderSegment(design, segment) {
 
         if(glyphObject.tooltip) {
 
+            if (glyphObject.isComposite)
+               glyphObject.tooltip = 'COMPOSITE' + glyphObject.tooltip;
+   
             glyph.attr('data-toggle', 'tooltip')
             glyph.attr('data-placement', 'top')
             glyph.attr('title', glyphObject.tooltip)
@@ -120,7 +151,12 @@ function renderSegment(design, segment) {
         glyphOffset += design.geom.glyphPadding;
 
         var group = surface.group().add(glyph);
-
+        
+        //if glyph object is composite, Add composite glyph to the object 
+        if (glyphObject.isComposite) { 
+           group.add(compositeGlyph);
+        }
+       
         if(labelText !== undefined)
             group.add(labelText);
 
@@ -135,6 +171,7 @@ function renderSegment(design, segment) {
     });
 
     if(segment.topologies.includes("circular")) {
+         
         var backbone = surface.rect(design.geom.segmentPadding + glyphOffset, 3 * boundingBoxSize.y)
 
         backbone.attr('fill', 'none');

--- a/lib/segment.js
+++ b/lib/segment.js
@@ -5,7 +5,7 @@ var Rect = require('./geom/rect'),
     Composite = require('../font/sbolv/composite')
 
 function renderSegment(design, segment) {
-   
+     
     var surface = design.surface;
 
     var glyphOffset = 0;
@@ -125,10 +125,10 @@ function renderSegment(design, segment) {
                
               label.attr('fill', glyphObject.labelColor );
             }
-            else if (segment.labelColor ) {
+            /*else if (segment.labelColor ) {
                
               label.attr('fill', segment.labelColor );
-            }
+            }*/
 
             label.attr('alignment-baseline', 'middle');
              
@@ -147,14 +147,10 @@ function renderSegment(design, segment) {
         }
 
         if(glyphObject.tooltip) {
-
-            if (glyphObject.isComposite)
-               glyphObject.tooltip = 'COMPOSITE' + glyphObject.tooltip;
-   
+  
             glyph.attr('data-toggle', 'tooltip')
             glyph.attr('data-placement', 'top')
             glyph.attr('title', glyphObject.tooltip)
-
         }
 
         glyphOffset += boundingBoxSize.x;
@@ -216,6 +212,10 @@ function renderSegment(design, segment) {
         labelText.build(true);
 
         var label = labelText.tspan(segment.name);
+
+         if (segment.labelColor) {
+            label.attr('fill', segment.labelColor );
+         }
 
         label.attr('alignment-baseline', 'middle');
         labelText.build(false);

--- a/lib/segment.js
+++ b/lib/segment.js
@@ -111,17 +111,27 @@ function renderSegment(design, segment) {
             labelText.build(true);
 
             var label;
+            label = labelText.tspan(glyphObject.name);
             
             //Add "composite" string to label if glyph object is composite
-            if (glyphObject.isComposite) {
+            /*if (glyphObject.isComposite) {
               label = labelText.tspan('Composite ' + glyphObject.name);
             }
             else {
               label = labelText.tspan(glyphObject.name);
+            }*/
+
+            if (glyphObject.labelColor ) {
+               
+              label.attr('fill', glyphObject.labelColor );
+            }
+            else if (segment.labelColor ) {
+               
+              label.attr('fill', segment.labelColor );
             }
 
             label.attr('alignment-baseline', 'middle');
-
+             
             labelText.build(false);
 
             var labelPos = Vec2(

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "rdf-ext": "^1.1.0",
     "rdf-graph-abstract": "^0.3.0",
     "rdf-parser-rdfxml": "^0.3.0-rc1"
+     
   },
   "devDependencies": {},
   "scripts": {


### PR DESCRIPTION
Addresses issues #21 and #46 

![screen shot 2018-06-14 at 14 57 17](https://user-images.githubusercontent.com/7750862/41432656-b158436a-6fe4-11e8-883d-c038fdf67ca9.png)

@asadeg02  added a library of 41 colors to make sub-parts easier to find
@StephanieGomez8  also modified all the glyphs with a stem because they were not sitting on the backbone and it only became an apparent issue when we attached the composite glyph