### PR TITLE
Updated the way composite parts are detected

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -229,12 +229,13 @@ var editors = [
 
             var interactions = [];
 
-            sbol.componentDefinitions.forEach(function(componentDefinition) {             
+            sbol.componentDefinitions.forEach(function(componentDefinition) { 
+                 
                 component.segments = component.segments.concat(getDisplayList(componentDefinition).components[0].segments[0])
             })
 
-            //processing module definition
-            sbol.moduleDefinitions.forEach(function(moduleDefinition) {
+           //processing module definition
+           sbol.moduleDefinitions.forEach(function(moduleDefinition) {
 
                currentInteractions = getInteractionList(moduleDefinition);
                for (let i in currentInteractions) {

--- a/lib/component.js
+++ b/lib/component.js
@@ -65,37 +65,32 @@ helper.circuit_is_participant = function(segment, interactions) {
 }
 
 function renderComponent(design, component, interactions) {
-      
+    
     //initializing color object for coloring sub part labels
     let colors = {};
     colors.colors = Colors.colors;
     colors.colorIndex = 0;
 
-   //populating compositeGlyph array
-    let compositeGlyphs = [];
-    for (let i = 0; i < component.segments.length; ++i) {
-      if ( component.segments[i].sequence.length > 1 ||
-           (component.segments[i].sequence.length === 1 && component.segments[i].name !== component.segments[i].sequence[0].name)) {
-        compositeGlyphs.push({name: component.segments[i].name, segmentIndex: i});
-      }
+    //creating a dictionary of segments, the key is the segment name
+    let segmentsDict = {};
+    for (segment of component.segments) {
+      segmentsDict[segment.name] = segment;
     }
-
-   //detecting composite glyphs and coloring composite parts  and their subpart labels
-    for (let i = 0; i < component.segments.length; ++i) {
-      for (let j in compositeGlyphs) {
-        for (let k in component.segments[i].sequence) {
-          if ( component.segments[i].sequence[k].name === compositeGlyphs[j].name)  {
-            component.segments[i].sequence[k].isComposite = true;
-            if ( colors.colorIndex < colors.colors.length ) {
-              //set the label color for composite glyph
-              component.segments[i].sequence[k].labelColor = colors.colors[colors.colorIndex].colorName;
-              //set the label color for subParts
-              component.segments[compositeGlyphs[j].segmentIndex].labelColor = colors.colors[colors.colorIndex++].colorName;
-            }
+  
+    
+    for (segment of component.segments) {
+      for (glyph of segment.sequence) {
+        if (glyph.isComposite) {
+          if ( colors.colorIndex < colors.colors.length ) {
+            //set the label color for composite glyph
+            glyph.labelColor = colors.colors[colors.colorIndex].colorName;
+            //set the label color for subParts
+            segmentsDict[glyph.segmentIdentity].labelColor = colors.colors[colors.colorIndex++].colorName;
           }
         }
       }
     }
+  
     
     //removing segments participating in interactions from component
     if (interactions.length !== 0) {

--- a/lib/displayList.js
+++ b/lib/displayList.js
@@ -138,6 +138,12 @@ DisplayList.Glyph = function Glyph(displayList, glyphObject) {
     this.end = glyphObject.end || this.start;
     this.uri = glyphObject.uri || ''
     this.tooltip = glyphObject.tooltip || ''
+    //Add this field, since render segment is going to look into this field
+    this.isComposite = glyphObject.isComposite;
+    //segment identity is the unique name of the corresponding segment for glyph
+    if (glyphObject.segmentIdentity) {
+      this.segmentIdentity = glyphObject.segmentIdentity;
+    } 
 }
 
 DisplayList.Process = function Process(displayList, process) {

--- a/lib/getDisplayList.js
+++ b/lib/getDisplayList.js
@@ -2,14 +2,13 @@ var soToGlyphType = require('./soToGlyphType');
 var soToTopology = require('./soToTopology');
 var nonDNATypes = require('./nonDNATypes');
 
-
 var sbolmeta = require('sbolmeta')
 
 var URI = require('sboljs').URI
 var sha1 = require('sha1');
 
 function getDisplayList(componentDefinition, config, share, max) {
-
+    console.log("componentDefinition", componentDefinition);
     var segments = [
         getDisplayListSegment(componentDefinition, config, share)
     ]
@@ -106,7 +105,7 @@ function getDisplayListSegment(componentDefinition, config, share) {
 
     if (componentDefinition.sequenceAnnotations.length === 0 && componentDefinition.components.length === 0) {
 
-
+        //console.log(componentDefinition);
         var glyph = 'unspecified'
         var name = componentDefinition.name != '' ? componentDefinition.name : componentDefinition.displayId
         var roles = componentDefinition.roles
@@ -170,7 +169,7 @@ function getDisplayListSegment(componentDefinition, config, share) {
               glyph = 'no-glyph-assigned';
             }
         })
-
+              
         return {
             name: displayName,
             sequence: [{
@@ -179,7 +178,9 @@ function getDisplayListSegment(componentDefinition, config, share) {
                 id: componentDefinition.uri + '',
                 name: name,
                 uri: uri,
-                tooltip: tooltip
+                tooltip: tooltip,
+                isComposite: false
+                      
             }],
             topologies: topologies
         }
@@ -188,7 +189,7 @@ function getDisplayListSegment(componentDefinition, config, share) {
     return {
         name: displayName,
         sequence: sortedSequenceAnnotations(componentDefinition).map((sequenceAnnotation) => {
-
+                        
             var glyph = 'unspecified'
 
             var name = sequenceAnnotation.name != '' ? sequenceAnnotation.name : sequenceAnnotation.displayId
@@ -212,6 +213,7 @@ function getDisplayListSegment(componentDefinition, config, share) {
                     roles = roles.concat(component.definition.roles)
 
                     name = component.definition.name != '' ? component.definition.name : component.definition.displayId
+                     
 
                     uri = component.definition.uri.toString()
 
@@ -227,7 +229,11 @@ function getDisplayListSegment(componentDefinition, config, share) {
                     if (component.definition.name) tooltip += 'Name: ' + component.definition.name + '\n'
                     if (component.definition.description) tooltip += 'Description: ' + component.definition.description + '\n'
                 } else {
+ 
+                     
+                    if (component.definition)
                     uri = component.definition.toString()
+ 
 
                     if (config && uri.startsWith(config.get('databasePrefix'))) {
                         if (uri.startsWith(config.get('databasePrefix') + 'user/') && share) {
@@ -309,13 +315,29 @@ function getDisplayListSegment(componentDefinition, config, share) {
         }
             })
 
+            let isComposite = false;
+            if (sequenceAnnotation.component.definition &&  sequenceAnnotation.component.definition.components.length > 0 ) {
+                isComposite = true;
+            }
+
+            let segmentIdentity = "";
+            if (sequenceAnnotation.component.definition) {
+                if(sequenceAnnotation.component.definition.name != '' && sequenceAnnotation.component.definition.name != sequenceAnnotation.component.definition.displayId)
+                    segmentIdentity = ' (' + sequenceAnnotation.component.definition.name + ')' ;
+                else
+                    segmentIdentity = sequenceAnnotation.component.definition.displayId
+            }
+            
             return {
                 strand: strand,
                 type: glyph,
                 id: sequenceAnnotation.uri + '',
                 name: name,
                 uri: uri,
-                tooltip: tooltip
+                tooltip: tooltip,
+                //extra field for detecting composites
+                isComposite: isComposite,
+                segmentIdentity: segmentIdentity
             }
         }),
         topologies: topologies

--- a/package.json
+++ b/package.json
@@ -4,14 +4,13 @@
   "description": "SBOLv rendering in JavaScript",
   "main": "index.js",
   "dependencies": {
-    "sboljs": "^2.0.0",
+    "rdf-ext": "^1.1.2",
+    "rdf-graph-abstract": "^0.3.0",
+    "rdf-parser-rdfxml": "^0.3.0-rc1",
+    "sboljs": "^2.1.9",
     "sbolmeta": "^0.1.10",
     "sha1": "^1.1.1",
-    "urijs": "^1.16.1",
-    "rdf-ext": "^1.1.0",
-    "rdf-graph-abstract": "^0.3.0",
-    "rdf-parser-rdfxml": "^0.3.0-rc1"
-     
+    "urijs": "^1.16.1"
   },
   "devDependencies": {},
   "scripts": {


### PR DESCRIPTION
Changed detection of composites from looking at names to looking at the SBOL structure directly by checking length of components array

Below are 2 rendering of the same [SBOL](https://synbiohub.org/public/iGEM_2016_interlab/Medium_2016Interlab/1), the first is based on the old detection method, which is wrong

![before](https://user-images.githubusercontent.com/7750862/47665489-9a3bc680-db77-11e8-9a85-0d2b533f7345.png)

the second is the new correct detection 
![after](https://user-images.githubusercontent.com/7750862/47665499-a1fb6b00-db77-11e8-976d-51d7af7ef2c9.png)